### PR TITLE
Add helper method to mock redis scripts

### DIFF
--- a/command.go
+++ b/command.go
@@ -36,6 +36,9 @@ func Command(commandName string, args ...interface{}) *Cmd {
 	return cmd
 }
 
+// Script registers a command in the mock system just like Command method would do
+// The first argument is a byte array with the script text, next ones are the ones
+// you would pass to redis Script.Do() method
 func Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd {
 	h := sha1.New()
 	h.Write(scriptData)

--- a/command.go
+++ b/command.go
@@ -4,7 +4,11 @@
 
 package redigomock
 
-import "reflect"
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"reflect"
+)
 
 var (
 	commands []*Cmd // Global variable that stores all registered commands
@@ -28,6 +32,25 @@ func Command(commandName string, args ...interface{}) *Cmd {
 	}
 
 	removeRelatedCommands(commandName, args)
+	commands = append(commands, cmd)
+	return cmd
+}
+
+func Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd {
+	h := sha1.New()
+	h.Write(scriptData)
+	sha1sum := hex.EncodeToString(h.Sum(nil))
+
+	newArgs := make([]interface{}, 2+len(args))
+	newArgs[0] = sha1sum
+	newArgs[1] = keyCount
+	copy(newArgs[2:], args)
+
+	cmd := &Cmd{
+		Name: "EVALSHA",
+		Args: newArgs,
+	}
+	removeRelatedCommands("EVALSHA", newArgs)
 	commands = append(commands, cmd)
 	return cmd
 }

--- a/command_test.go
+++ b/command_test.go
@@ -5,6 +5,8 @@
 package redigomock
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"testing"
 )
@@ -14,7 +16,7 @@ func TestCommand(t *testing.T) {
 
 	Command("HGETALL", "a", "b", "c")
 	if len(commands) != 1 {
-		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(commands))
+		t.Fatalf("Did not register the command. Expected '1' and got '%d'", len(commands))
 	}
 
 	cmd := commands[0]
@@ -48,6 +50,111 @@ func TestCommand(t *testing.T) {
 
 	if cmd.Error != nil {
 		t.Error("Error defined without any call")
+	}
+}
+
+func TestScript(t *testing.T) {
+	commands = []*Cmd{}
+
+	scriptData := []byte("This should be a lua script for redis")
+	h := sha1.New()
+	h.Write(scriptData)
+	sha1sum := hex.EncodeToString(h.Sum(nil))
+
+	Script(scriptData, 0)                           //0
+	Script(scriptData, 0, "value1")                 //1
+	Script(scriptData, 1, "key1")                   //2
+	Script(scriptData, 1, "key1", "value1")         //3
+	Script(scriptData, 2, "key1", "key2", "value1") //4
+
+	if len(commands) != 5 {
+		t.Fatalf("Did not register the commands. Expected '4' and got '%d'", len(commands))
+	}
+
+	if commands[0].Name != "EVALSHA" {
+		t.Error("Wrong name defined for command")
+	}
+
+	if len(commands[0].Args) != 2 {
+		t.Errorf("Wrong arguments defined for command %v", commands[0].Args)
+	}
+
+	if len(commands[1].Args) != 3 {
+		t.Error("Wrong arguments defined for command")
+	}
+
+	if len(commands[2].Args) != 3 {
+		t.Error("Wrong arguments defined for command")
+	}
+
+	if len(commands[3].Args) != 4 {
+		t.Error("Wrong arguments defined for command")
+	}
+
+	if len(commands[4].Args) != 5 {
+		t.Error("Wrong arguments defined for command")
+	}
+
+	//Script(scriptData, 0)
+	arg := commands[0].Args[0].(string)
+	if arg != sha1sum {
+		t.Errorf("Wrong argument defined for command. Expected '%s' and got '%s'", sha1sum, arg)
+	}
+	argInt := commands[0].Args[1].(int)
+	if argInt != 0 {
+		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
+	}
+
+	//Script(scriptData, 0, "value1")
+	argInt = commands[1].Args[1].(int)
+	if argInt != 0 {
+		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
+	}
+	arg = commands[1].Args[2].(string)
+	if arg != "value1" {
+		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
+	}
+
+	//Script(scriptData, 1, "key1")
+	argInt = commands[2].Args[1].(int)
+	if argInt != 1 {
+		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
+	}
+	arg = commands[2].Args[2].(string)
+	if arg != "key1" {
+		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
+	}
+
+	//Script(scriptData, 1, "key1", "value1")
+	argInt = commands[3].Args[1].(int)
+	if argInt != 1 {
+		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
+	}
+	arg = commands[3].Args[2].(string)
+	if arg != "key1" {
+		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
+	}
+	arg = commands[3].Args[3].(string)
+	if arg != "value1" {
+		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
+	}
+
+	//Script(scriptData, 2, "key1", "key2", "value1")
+	argInt = commands[4].Args[1].(int)
+	if argInt != 2 {
+		t.Errorf("Wrong argument defined for command. Expected '2' and got '%v'", argInt)
+	}
+	arg = commands[4].Args[2].(string)
+	if arg != "key1" {
+		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
+	}
+	arg = commands[4].Args[3].(string)
+	if arg != "key2" {
+		t.Errorf("Wrong argument defined for command. Expected 'key2' and got '%s'", arg)
+	}
+	arg = commands[4].Args[4].(string)
+	if arg != "value1" {
+		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 }
 

--- a/redigomock.go
+++ b/redigomock.go
@@ -6,6 +6,7 @@ package redigomock
 
 import (
 	"fmt"
+
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -85,7 +86,7 @@ func (c Conn) Receive() (reply interface{}, err error) {
 	return
 }
 
-// Clear remove all registered commands and empty the queue
+// Clear removes all registered commands and empty the queue
 func Clear() {
 	queue = []struct {
 		commandName string


### PR DESCRIPTION
Added a small helper method allowing me to mock redis lua scripts. You need to pass the byte array with script text as a first argument, following arguments are working just like for Command method