### PR TITLE
Make redigomock compatible with tests run in parallel

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 ### Added
 - Fuzzy matching for redigomock command arguments
+- Make commands a property of a connection object, which allows to run tests in pararell
 
 ## [1.0.0] - 2015-04-23
 ### Added

--- a/command.go
+++ b/command.go
@@ -10,10 +10,6 @@ import (
 	"reflect"
 )
 
-var (
-	commands []*Cmd // Global variable that stores all registered commands
-)
-
 // Response struct that represents single response from `Do` call
 type Response struct {
 	Response interface{} // Response to send back when this command/arguments are called
@@ -30,21 +26,20 @@ type Cmd struct {
 
 // Command register a command in the mock system using the same arguments of a Do or Send commands.
 // It will return a registered command object where you can set the response or error
-func Command(commandName string, args ...interface{}) *Cmd {
+func (c *Conn) Command(commandName string, args ...interface{}) *Cmd {
 	cmd := &Cmd{
 		Name: commandName,
 		Args: args,
 	}
-
-	removeRelatedCommands(commandName, args)
-	commands = append(commands, cmd)
+	c.removeRelatedCommands(commandName, args)
+	c.commands = append(c.commands, cmd)
 	return cmd
 }
 
 // Script registers a command in the mock system just like Command method would do
 // The first argument is a byte array with the script text, next ones are the ones
 // you would pass to redis Script.Do() method
-func Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd {
+func (c *Conn) Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd {
 	h := sha1.New()
 	h.Write(scriptData)
 	sha1sum := hex.EncodeToString(h.Sum(nil))
@@ -54,52 +49,25 @@ func Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd {
 	newArgs[1] = keyCount
 	copy(newArgs[2:], args)
 
-	return Command("EVALSHA", newArgs...)
+	return c.Command("EVALSHA", newArgs...)
 }
 
 // GenericCommand register a command without arguments. If a command with arguments doesn't match
 // with any registered command, it will look for generic commands before throwing an error
-func GenericCommand(commandName string) *Cmd {
+func (c *Conn) GenericCommand(commandName string) *Cmd {
 	cmd := &Cmd{
 		Name: commandName,
 	}
 
-	removeRelatedCommands(commandName, nil)
-	commands = append(commands, cmd)
+	c.removeRelatedCommands(commandName, nil)
+	c.commands = append(c.commands, cmd)
 	return cmd
-}
-
-// Expect sets a response for this command. Everytime a Do or Receive methods are executed for a
-// registered command this response or error will be returned. Expect call returns a pointer to Cmd struct,
-// so you can chain Expect calls. Chained responses will be returned on subsequend calls matching this commands arguments
-// in FIFO order.
-func (c *Cmd) Expect(response interface{}) *Cmd {
-	c.Responses = append(c.Responses, Response{response, nil})
-	return c
-}
-
-// ExpectMap works in the same way of the Expect command, but has a key/value input to make it
-// easier to build test environments
-func (c *Cmd) ExpectMap(response map[string]string) *Cmd {
-	var values []interface{}
-	for key, value := range response {
-		values = append(values, []byte(key))
-		values = append(values, []byte(value))
-	}
-	c.Responses = append(c.Responses, Response{values, nil})
-	return c
-}
-
-// ExpectError allows you to force an error when executing a command/arguments
-func (c *Cmd) ExpectError(err error) *Cmd {
-	c.Responses = append(c.Responses, Response{nil, err})
-	return c
 }
 
 //find will scan the registered commands, looking for the first command with the same name and
 //arguments. If the command is not found nil is returned
-func find(commandName string, args []interface{}) *Cmd {
-	for _, cmd := range commands {
+func (c *Conn) find(commandName string, args []interface{}) *Cmd {
+	for _, cmd := range c.commands {
 		if match(commandName, args, cmd) {
 			return cmd
 		}
@@ -109,16 +77,20 @@ func find(commandName string, args []interface{}) *Cmd {
 
 // removeRelatedCommands verify if a command is already registered, removing any command already
 // registered with the same name and arguments. This should avoid duplicated mocked commands
-func removeRelatedCommands(commandName string, args []interface{}) {
+func (c *Conn) removeRelatedCommands(commandName string, args []interface{}) {
 	var unique []*Cmd
 
-	for _, cmd := range commands {
+	for _, cmd := range c.commands {
 		// New array will contain only commands that are not related to the given one
 		if !equal(commandName, args, cmd) {
 			unique = append(unique, cmd)
 		}
 	}
-	commands = unique
+	c.commands = unique
+}
+
+func (c *Conn) Clear() {
+	c.commands = []*Cmd{}
 }
 
 // match verify if a command/argumets is related to a registered command.
@@ -160,4 +132,31 @@ func match(commandName string, args []interface{}, cmd *Cmd) bool {
 
 	}
 	return true
+}
+
+// Expect sets a response for this command. Everytime a Do or Receive methods are executed for a
+// registered command this response or error will be returned. Expect call returns a pointer to Cmd struct,
+// so you can chain Expect calls. Chained responses will be returned on subsequend calls matching this commands arguments
+// in FIFO order.
+func (c *Cmd) Expect(response interface{}) *Cmd {
+	c.Responses = append(c.Responses, Response{response, nil})
+	return c
+}
+
+// ExpectMap works in the same way of the Expect command, but has a key/value input to make it
+// easier to build test environments
+func (c *Cmd) ExpectMap(response map[string]string) *Cmd {
+	var values []interface{}
+	for key, value := range response {
+		values = append(values, []byte(key))
+		values = append(values, []byte(value))
+	}
+	c.Responses = append(c.Responses, Response{values, nil})
+	return c
+}
+
+// ExpectError allows you to force an error when executing a command/arguments
+func (c *Cmd) ExpectError(err error) *Cmd {
+	c.Responses = append(c.Responses, Response{nil, err})
+	return c
 }

--- a/command_test.go
+++ b/command_test.go
@@ -12,17 +12,13 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	commands = []*Cmd{}
-
-	Command("HGETALL", "a", "b", "c")
-	if len(commands) != 1 {
-		t.Fatalf("Did not register the command. Expected '1' and got '%d'", len(commands))
-	}
-	if len(fuzzyCommands) != 0 {
-		t.Errorf("Added non fuzzy command to fuzzy command list")
+	connection := NewConn()
+	connection.Command("HGETALL", "a", "b", "c")
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not register the command. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Name != "HGETALL" {
 		t.Error("Wrong name defined for command")
@@ -53,119 +49,118 @@ func TestCommand(t *testing.T) {
 }
 
 func TestScript(t *testing.T) {
-	commands = []*Cmd{}
-
+	connection := NewConn()
 	scriptData := []byte("This should be a lua script for redis")
 	h := sha1.New()
 	h.Write(scriptData)
 	sha1sum := hex.EncodeToString(h.Sum(nil))
 
-	Script(scriptData, 0)                           //0
-	Script(scriptData, 0, "value1")                 //1
-	Script(scriptData, 1, "key1")                   //2
-	Script(scriptData, 1, "key1", "value1")         //3
-	Script(scriptData, 2, "key1", "key2", "value1") //4
+	connection.Script(scriptData, 0)                           //0
+	connection.Script(scriptData, 0, "value1")                 //1
+	connection.Script(scriptData, 1, "key1")                   //2
+	connection.Script(scriptData, 1, "key1", "value1")         //3
+	connection.Script(scriptData, 2, "key1", "key2", "value1") //4
 
-	if len(commands) != 5 {
-		t.Fatalf("Did not register the commands. Expected '5' and got '%d'", len(commands))
+	if len(connection.commands) != 5 {
+		t.Fatalf("Did not register the commands. Expected '5' and got '%d'", len(connection.commands))
 	}
 
-	if commands[0].Name != "EVALSHA" {
+	if connection.commands[0].Name != "EVALSHA" {
 		t.Error("Wrong name defined for command")
 	}
 
-	if len(commands[0].Args) != 2 {
-		t.Errorf("Wrong arguments defined for command %v", commands[0].Args)
+	if len(connection.commands[0].Args) != 2 {
+		t.Errorf("Wrong arguments defined for command %v", connection.commands[0].Args)
 	}
 
-	if len(commands[1].Args) != 3 {
+	if len(connection.commands[1].Args) != 3 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(commands[2].Args) != 3 {
+	if len(connection.commands[2].Args) != 3 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(commands[3].Args) != 4 {
+	if len(connection.commands[3].Args) != 4 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(commands[4].Args) != 5 {
+	if len(connection.commands[4].Args) != 5 {
 		t.Error("Wrong arguments defined for command")
 	}
 
 	//Script(scriptData, 0)
-	arg := commands[0].Args[0].(string)
+	arg := connection.commands[0].Args[0].(string)
 	if arg != sha1sum {
 		t.Errorf("Wrong argument defined for command. Expected '%s' and got '%s'", sha1sum, arg)
 	}
-	argInt := commands[0].Args[1].(int)
+	argInt := connection.commands[0].Args[1].(int)
 	if argInt != 0 {
 		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
 	}
 
 	//Script(scriptData, 0, "value1")
-	argInt = commands[1].Args[1].(int)
+	argInt = connection.commands[1].Args[1].(int)
 	if argInt != 0 {
 		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
 	}
-	arg = commands[1].Args[2].(string)
+	arg = connection.commands[1].Args[2].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 
 	//Script(scriptData, 1, "key1")
-	argInt = commands[2].Args[1].(int)
+	argInt = connection.commands[2].Args[1].(int)
 	if argInt != 1 {
 		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
 	}
-	arg = commands[2].Args[2].(string)
+	arg = connection.commands[2].Args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
 
 	//Script(scriptData, 1, "key1", "value1")
-	argInt = commands[3].Args[1].(int)
+	argInt = connection.commands[3].Args[1].(int)
 	if argInt != 1 {
 		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
 	}
-	arg = commands[3].Args[2].(string)
+	arg = connection.commands[3].Args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
-	arg = commands[3].Args[3].(string)
+	arg = connection.commands[3].Args[3].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 
 	//Script(scriptData, 2, "key1", "key2", "value1")
-	argInt = commands[4].Args[1].(int)
+	argInt = connection.commands[4].Args[1].(int)
 	if argInt != 2 {
 		t.Errorf("Wrong argument defined for command. Expected '2' and got '%v'", argInt)
 	}
-	arg = commands[4].Args[2].(string)
+	arg = connection.commands[4].Args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
-	arg = commands[4].Args[3].(string)
+	arg = connection.commands[4].Args[3].(string)
 	if arg != "key2" {
 		t.Errorf("Wrong argument defined for command. Expected 'key2' and got '%s'", arg)
 	}
-	arg = commands[4].Args[4].(string)
+	arg = connection.commands[4].Args[4].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 }
 
 func TestGenericCommand(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	GenericCommand("HGETALL")
-	if len(commands) != 1 {
-		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(commands))
+	connection.GenericCommand("HGETALL")
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Name != "HGETALL" {
 		t.Error("Wrong name defined for command")
@@ -181,14 +176,14 @@ func TestGenericCommand(t *testing.T) {
 }
 
 func TestExpect(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL").Expect("test")
-	if len(commands) != 1 {
-		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(commands))
+	connection.Command("HGETALL").Expect("test")
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Responses[0].Response == nil {
 		t.Fatal("Response not defined")
@@ -205,17 +200,17 @@ func TestExpect(t *testing.T) {
 }
 
 func TestExpectMap(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL").ExpectMap(map[string]string{
+	connection.Command("HGETALL").ExpectMap(map[string]string{
 		"key1": "value1",
 	})
 
-	if len(commands) != 1 {
-		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(commands))
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Responses[0].Response == nil {
 		t.Fatal("Response not defined")
@@ -246,21 +241,21 @@ func TestExpectMap(t *testing.T) {
 }
 
 func TestExpectMapReplace(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL").ExpectMap(map[string]string{
+	connection.Command("HGETALL").ExpectMap(map[string]string{
 		"key1": "value1",
 	})
 
-	Command("HGETALL").ExpectMap(map[string]string{
+	connection.Command("HGETALL").ExpectMap(map[string]string{
 		"key2": "value2",
 	})
 
-	if len(commands) != 1 {
-		t.Fatalf("Wrong number of registered commands. Expected '1' and got '%d'", len(commands))
+	if len(connection.commands) != 1 {
+		t.Fatalf("Wrong number of registered commands. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Responses[0].Response == nil {
 		t.Fatal("Response not defined")
@@ -291,15 +286,15 @@ func TestExpectMapReplace(t *testing.T) {
 }
 
 func TestExpectError(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL").ExpectError(fmt.Errorf("error"))
+	connection.Command("HGETALL").ExpectError(fmt.Errorf("error"))
 
-	if len(commands) != 1 {
-		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(commands))
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
 	}
 
-	cmd := commands[0]
+	cmd := connection.commands[0]
 
 	if cmd.Responses[0].Error == nil {
 		t.Fatal("Error not defined")
@@ -311,39 +306,39 @@ func TestExpectError(t *testing.T) {
 }
 
 func TestFind(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "a", "b", "c")
+	connection.Command("HGETALL", "a", "b", "c")
 
-	if find("HGETALL", []interface{}{"a"}) != nil {
+	if connection.find("HGETALL", []interface{}{"a"}) != nil {
 		t.Error("Returning command without comparing all registered arguments")
 	}
 
-	if find("HGETALL", []interface{}{"a", "b", "c", "d"}) != nil {
+	if connection.find("HGETALL", []interface{}{"a", "b", "c", "d"}) != nil {
 		t.Error("Returning command without comparing all informed arguments")
 	}
 
-	if find("HSETALL", []interface{}{"a", "b", "c"}) != nil {
+	if connection.find("HSETALL", []interface{}{"a", "b", "c"}) != nil {
 		t.Error("Returning command when the name is different")
 	}
 
-	if find("HGETALL", []interface{}{"a", "b", "c"}) == nil {
+	if connection.find("HGETALL", []interface{}{"a", "b", "c"}) == nil {
 		t.Error("Could not find command with arguments in the same order")
 	}
 }
 
 func TestRemoveRelatedCommands(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "a", "b", "c") // 1
-	Command("HGETALL", "a", "b", "c") // omit
-	Command("HGETALL", "c", "b", "a") // 2
-	Command("HGETALL")                //3
-	Command("HSETALL", "c", "b", "a") // 4
-	Command("HSETALL")                //5
+	connection.Command("HGETALL", "a", "b", "c") // 1
+	connection.Command("HGETALL", "a", "b", "c") // omit
+	connection.Command("HGETALL", "c", "b", "a") // 2
+	connection.Command("HGETALL")                //3
+	connection.Command("HSETALL", "c", "b", "a") // 4
+	connection.Command("HSETALL")                //5
 
-	if len(commands) != 5 {
-		t.Errorf("Not removing related commands. Expected '5' and got '%d'", len(commands))
+	if len(connection.commands) != 5 {
+		t.Errorf("Not removing related commands. Expected '5' and got '%d'", len(connection.commands))
 	}
 }
 

--- a/fuzzy_match.go
+++ b/fuzzy_match.go
@@ -2,10 +2,6 @@ package redigomock
 
 import "reflect"
 
-var (
-	fuzzyCommands []*Cmd // Global variable that stores all registered  fuzzy commands
-)
-
 // FuzzyMatcher is an interface that exports exports one function. It can be passed to the Command as a argument.
 // When the command is evaluated agains data provided in mock connection Do call, FuzzyMatcher will call Match on the
 //argument and returns true if argument fulfils constraints set in concrete implementation .

--- a/fuzzy_match_test.go
+++ b/fuzzy_match_test.go
@@ -71,7 +71,7 @@ func TestFuzzyCommandMatchAnyData(t *testing.T) {
 	}{
 		{[]interface{}{"TEST_COMMAND", "Test string", "Another string"}, true},
 		{[]interface{}{"TEST_COMMAND", "Test string", 12344}, true},
-		{[]interface{}{"TEST_COMMAND", "Test string", Command}, true}, // func
+		{[]interface{}{"TEST_COMMAND", "Test string", func() {}}, true}, // func
 		{[]interface{}{"TEST_COMMAND", "Test string", []string{"Slice of", "strings"}}, true},
 		{[]interface{}{"TEST_COMMAND", "Test string", "Another string", 11.22}, false},
 	}
@@ -89,45 +89,45 @@ func TestFuzzyCommandMatchAnyData(t *testing.T) {
 }
 
 func TestFindWithFuzzy(t *testing.T) {
-	commands = []*Cmd{}
-	
-	Command("HGETALL", NewAnyInt(), NewAnyDouble(), "Test string")
+	connection := NewConn()
 
-	if find("HGETALL", []interface{}{1, 2.0}) != nil {
+	connection.Command("HGETALL", NewAnyInt(), NewAnyDouble(), "Test string")
+
+	if connection.find("HGETALL", []interface{}{1, 2.0}) != nil {
 		t.Error("Returning command without comparing all registered arguments")
 	}
 
-	if find("HGETALL", []interface{}{1, 2.0, "Test string", "a"}) != nil {
+	if connection.find("HGETALL", []interface{}{1, 2.0, "Test string", "a"}) != nil {
 		t.Error("Returning command without comparing all informed arguments")
 	}
 
-	if find("HSETALL", []interface{}{1, 2.0, "Test string"}) != nil {
+	if connection.find("HSETALL", []interface{}{1, 2.0, "Test string"}) != nil {
 		t.Error("Returning command when the name is different")
 	}
 
-	if find("HGETALL", []interface{}{1.0, "Test string", 2}) != nil {
+	if connection.find("HGETALL", []interface{}{1.0, "Test string", 2}) != nil {
 		t.Error("Returning command with arguments in a different order")
 	}
 
-	if find("HGETALL", []interface{}{1, 2.0, "Test string"}) == nil {
+	if connection.find("HGETALL", []interface{}{1, 2.0, "Test string"}) == nil {
 		t.Error("Could not find command with arguments in the same order")
 	}
 }
 
 func TestRemoveRelatedFuzzyCommands(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", 1, 2.0, "c")                // saved , non fuzzy
-	Command("HGETALL", NewAnyInt(), 2.0, "c")      // saved , fuzzy
-	Command("HGETALL", NewAnyInt(), 2.0, "c")      // not saved!! , fuzzy
-	Command("COMMAND2", NewAnyInt(), 2.0, "c")     // saved , fuzzy
-	Command("HGETALL", NewAnyInt(), 5.0, "c")      // saved, fuzzy
-	Command("HGETALL", NewAnyInt(), 2.0, "d")      // saved, fuzzy
-	Command("HGETALL", NewAnyInt(), 2, "c")        // saved, fuzzy
-	Command("HGETALL", NewAnyInt(), 2.0, "c", "d") // saved, fuzzy
-	Command("HGETALL", 1, NewAnyDouble(), "c")     // saved, fuzzy
+	connection.Command("HGETALL", 1, 2.0, "c")                // saved , non fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 2.0, "c")      // saved , fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 2.0, "c")      // not saved!! , fuzzy
+	connection.Command("COMMAND2", NewAnyInt(), 2.0, "c")     // saved , fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 5.0, "c")      // saved, fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 2.0, "d")      // saved, fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 2, "c")        // saved, fuzzy
+	connection.Command("HGETALL", NewAnyInt(), 2.0, "c", "d") // saved, fuzzy
+	connection.Command("HGETALL", 1, NewAnyDouble(), "c")     // saved, fuzzy
 
-	if len(commands) != 8 {
-		t.Errorf("Non fuzzy command cound invalid, expected 8, got %d", len(commands))
+	if len(connection.commands) != 8 {
+		t.Errorf("Non fuzzy command cound invalid, expected 8, got %d", len(connection.commands))
 	}
 }

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -363,13 +363,12 @@ func TestClear(t *testing.T) {
 	connection.Send("HGETALL", "person:2")
 
 	connection.Clear()
-	ClearQueue()
 
 	if len(connection.commands) > 0 {
 		t.Error("Clear function not clearing registered commands")
 	}
 
-	if len(queue) > 0 {
+	if len(connection.queue) > 0 {
 		t.Error("Clear function not clearing the queue")
 	}
 }

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -51,14 +51,14 @@ func RetrievePeople(conn redis.Conn, ids []string) ([]Person, error) {
 }
 
 func TestDoCommand(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
 
-	person, err := RetrievePerson(NewConn(), "1")
+	person, err := RetrievePerson(connection, "1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,8 +73,9 @@ func TestDoCommand(t *testing.T) {
 }
 
 func TestDoCommandMultipleReturnValues(t *testing.T) {
-	commands = []*Cmd{}
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection := NewConn()
+
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	}).ExpectMap(map[string]string{
@@ -82,7 +83,7 @@ func TestDoCommandMultipleReturnValues(t *testing.T) {
 		"age":  "28",
 	}).ExpectError(fmt.Errorf("simulated error"))
 
-	person, err := RetrievePerson(NewConn(), "1")
+	person, err := RetrievePerson(connection, "1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +94,7 @@ func TestDoCommandMultipleReturnValues(t *testing.T) {
 		t.Errorf("Invalid age. Expected '42' and got '%d'", person.Age)
 	}
 
-	person, err = RetrievePerson(NewConn(), "1")
+	person, err = RetrievePerson(connection, "1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,21 +105,21 @@ func TestDoCommandMultipleReturnValues(t *testing.T) {
 		t.Errorf("Invalid age. Expected '28' and got '%d'", person.Age)
 	}
 
-	_, err = RetrievePerson(NewConn(), "1")
+	_, err = RetrievePerson(connection, "1")
 	if err == nil {
 		t.Error("Should return an error!")
 	}
 }
 
 func TestDoGenericCommand(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	GenericCommand("HGETALL").ExpectMap(map[string]string{
+	connection.GenericCommand("HGETALL").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
 
-	person, err := RetrievePerson(NewConn(), "1")
+	person, err := RetrievePerson(connection, "1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,19 +134,19 @@ func TestDoGenericCommand(t *testing.T) {
 }
 
 func TestDoCommandWithGeneric(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
 
-	GenericCommand("HGETALL").ExpectMap(map[string]string{
+	connection.GenericCommand("HGETALL").ExpectMap(map[string]string{
 		"name": "Mr. Mark",
 		"age":  "32",
 	})
 
-	person, err := RetrievePerson(NewConn(), "1")
+	person, err := RetrievePerson(connection, "1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,11 +161,11 @@ func TestDoCommandWithGeneric(t *testing.T) {
 }
 
 func TestDoCommandWithError(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectError(fmt.Errorf("simulated error"))
+	connection.Command("HGETALL", "person:1").ExpectError(fmt.Errorf("simulated error"))
 
-	_, err := RetrievePerson(NewConn(), "1")
+	_, err := RetrievePerson(connection, "1")
 	if err == nil {
 		t.Error("Should return an error!")
 		return
@@ -172,9 +173,9 @@ func TestDoCommandWithError(t *testing.T) {
 }
 
 func TestDoCommandWithUnexpectedCommand(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	_, err := RetrievePerson(NewConn(), "X")
+	_, err := RetrievePerson(connection, "X")
 	if err == nil {
 		t.Error("Should detect a command not registered!")
 		return
@@ -182,30 +183,29 @@ func TestDoCommandWithUnexpectedCommand(t *testing.T) {
 }
 
 func TestDoCommandWithoutResponse(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1")
+	connection.Command("HGETALL", "person:1")
 
-	_, err := RetrievePerson(NewConn(), "1")
+	_, err := RetrievePerson(connection, "1")
 	if err == nil {
 		t.Fatal("Returning an information when it shoudn't")
 	}
 }
 
 func TestSendFlushReceive(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
-	Command("HGETALL", "person:2").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:2").ExpectMap(map[string]string{
 		"name": "Ms. Jennifer",
 		"age":  "28",
 	})
 
-	conn := NewConn()
-	people, err := RetrievePeople(conn, []string{"1", "2"})
+	people, err := RetrievePeople(connection, []string{"1", "2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,27 +222,25 @@ func TestSendFlushReceive(t *testing.T) {
 		t.Error("People age order are wrong")
 	}
 
-	if _, err := conn.Receive(); err == nil {
+	if _, err := connection.Receive(); err == nil {
 		t.Error("Not detecting when there's no more items to receive")
 	}
 }
 
 func TestSendReceiveWithWait(t *testing.T) {
-	commands = []*Cmd{}
-
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
-		"name": "Mr. Johson",
-		"age":  "42",
-	})
-	Command("HGETALL", "person:2").ExpectMap(map[string]string{
-		"name": "Ms. Jennifer",
-		"age":  "28",
-	})
-
 	conn := Conn{
 		ReceiveWait: true,
 		ReceiveNow:  make(chan bool),
 	}
+
+	conn.Command("HGETALL", "person:1").ExpectMap(map[string]string{
+		"name": "Mr. Johson",
+		"age":  "42",
+	})
+	conn.Command("HGETALL", "person:2").ExpectMap(map[string]string{
+		"name": "Ms. Jennifer",
+		"age":  "28",
+	})
 
 	ids := []string{"1", "2"}
 	for _, id := range ids {
@@ -287,19 +285,19 @@ func TestSendReceiveWithWait(t *testing.T) {
 }
 
 func TestSendFlushReceiveWithError(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
-	Command("HGETALL", "person:2").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:2").ExpectMap(map[string]string{
 		"name": "Ms. Jennifer",
 		"age":  "28",
 	})
-	Command("HGETALL", "person:2").ExpectError(fmt.Errorf("simulated error"))
+	connection.Command("HGETALL", "person:2").ExpectError(fmt.Errorf("simulated error"))
 
-	_, err := RetrievePeople(NewConn(), []string{"1", "2", "3"})
+	_, err := RetrievePeople(connection, []string{"1", "2", "3"})
 	if err == nil {
 		t.Error("Not detecting error when using send/flush/receive")
 	}
@@ -346,28 +344,28 @@ func TestDummyFunctions(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
-	commands = []*Cmd{}
+	connection := NewConn()
 
-	Command("HGETALL", "person:1").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:1").ExpectMap(map[string]string{
 		"name": "Mr. Johson",
 		"age":  "42",
 	})
-	Command("HGETALL", "person:2").ExpectMap(map[string]string{
+	connection.Command("HGETALL", "person:2").ExpectMap(map[string]string{
 		"name": "Ms. Jennifer",
 		"age":  "28",
 	})
-	GenericCommand("HGETALL").ExpectMap(map[string]string{
+	connection.GenericCommand("HGETALL").ExpectMap(map[string]string{
 		"name": "Ms. Mark",
 		"age":  "32",
 	})
 
-	conn := NewConn()
-	conn.Send("HGETALL", "person:1")
-	conn.Send("HGETALL", "person:2")
+	connection.Send("HGETALL", "person:1")
+	connection.Send("HGETALL", "person:2")
 
-	Clear()
+	connection.Clear()
+	ClearQueue()
 
-	if len(commands) > 0 {
+	if len(connection.commands) > 0 {
 		t.Error("Clear function not clearing registered commands")
 	}
 


### PR DESCRIPTION
Hi Rafael, 
This is another breaking change. I do believe  that the benefits are worth breaking backward compatibility.  
I have moved command and queue lists into the connection object. 
This way tests using redigomock could be run in parallel. This would be really beneficial in larger projects. 

Please have a look and tell me what you think


Best regards, 
Maciej 
 