### PR TITLE
Conn.Do() flushes command queue

### DIFF
--- a/redigomock.go
+++ b/redigomock.go
@@ -153,11 +153,12 @@ func (c *Conn) Do(commandName string, args ...interface{}) (reply interface{}, e
 		}
 	}
 
+	c.stats[cmd.hash()]++
+
 	if len(cmd.Responses) == 0 {
 		return nil, nil
 	}
 
-	c.stats[cmd.hash()]++
 	response := cmd.Responses[0]
 	cmd.Responses = cmd.Responses[1:]
 	return response.Response, response.Error

--- a/redigomock.go
+++ b/redigomock.go
@@ -136,6 +136,14 @@ func (c *Conn) Clear() {
 // response or error is returned. If no registered command is found an error
 // is returned
 func (c *Conn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+	queueLength := len(c.queue)
+	if queueLength > 0 {
+		// Process the queued commands first
+		cmd := c.queue[0]
+		c.queue = c.queue[1:]
+		reply, err = c.Do(cmd.commandName, cmd.args...)
+	}
+
 	cmd := c.find(commandName, args)
 	if cmd == nil {
 		// Didn't find a specific command, try to get a generic one


### PR DESCRIPTION
I was having a problem where I wanted to setup mocks around a transaction using redigo, e.g.,

```go
cmd1 := connection.Command("MULTI")
cmd2 := connection.Command("SET", "person-123", 123456)
cmd3 := connection.Command("EXPIRE", "person-123", 1000)
cmd4 := connection.Command("EXEC").Expect([]interface{}{"OK", "OK"})

connection.Send("MULTI")
connection.Send("SET", "person-123", 123456)
connection.Send("EXPIRE", "person-123", 1000)
connection.Do("EXEC")

assert.Equal(t, 1, conn.Stats(cmd1))
```

This wasn't working for two reasons:

1. The only way that `Send()`command invocations were getting tracked in stats was by explicitly calling `Receive()` but I was flushing the queue with `Do()` 
2. Even if the queue were getting processed, stats weren't being tracked because only commands that supplied an expected response were getting tracked. It seemed that every invocation should have stats tracked.

The solution was to flush the command queue when calling Do(), and ensure that every command 'invocation' is tracked in the stats collection.

