### PR TITLE
Return erros when a command in a transaction is results in an error

### DIFF
--- a/redigomock.go
+++ b/redigomock.go
@@ -143,6 +143,9 @@ func (c *Conn) Do(commandName string, args ...interface{}) (reply interface{}, e
 		cmd := c.queue[0]
 		c.queue = c.queue[1:]
 		reply, err = c.Do(cmd.commandName, cmd.args...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	cmd := c.find(commandName, args)

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -584,3 +584,19 @@ func TestReceiveReturnsErrorWithNoRegisteredCommand(t *testing.T) {
 		t.Errorf("Should have returned a nil response when calling Receive with a command in the queue that was not registered")
 	}
 }
+
+func TestFailCommandOnTransaction(t *testing.T) {
+	connection := NewConn()
+
+	connection.Command("MULTI")
+	connection.Command("SET", "person-123", 123456)
+	connection.Command("EXEC").Expect([]interface{}{"OK", "OK"})
+
+	connection.Send("MULTI")
+	connection.Send("SET", "person-321", 654321)
+	_, err := connection.Do("EXEC")
+
+	if err == nil {
+		t.Errorf("Should have received an error when calling EXEC with a transaction with a command that was not registered")
+	}
+}


### PR DESCRIPTION
I was having some trouble debugging a queued command that I setup incorrectly (typo in the argument).  No error was printed to stdout or returned, so this fixes that.

I also tried running a MULTI block with a bad HSET to see what happened with the real redigo lib, and I got an error back from the Do('EXEC') line:

`ERR wrong number of arguments for 'hset' command`

So this matches that behaviour.