### PR TITLE
Improve error message with suggestions

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,11 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Added
 - Fuzzy matching for redigomock command arguments
 - Make commands a property of a connection object, which allows to run tests in parallel
 - Commands calls counters, which allows to identify unused mocked commands (thanks to @rylnd)
+
+### Changed
+- Improve error message adding argument suggestions
 
 ## [1.0.0] - 2015-04-23
 ### Added

--- a/redigomock.go
+++ b/redigomock.go
@@ -157,8 +157,18 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	if cmd == nil {
 		// Didn't find a specific command, try to get a generic one
 		if cmd = c.find(commandName, nil); cmd == nil {
-			return nil, fmt.Errorf("command %s with arguments %#v not registered in redigomock library",
-				commandName, args)
+			var msg string
+			for _, regCmd := range c.commands {
+				if commandName == regCmd.Name {
+					if len(msg) == 0 {
+						msg = ". Possible matches are with the arguments:"
+					}
+					msg += fmt.Sprintf("\n* %#v", regCmd.Args)
+				}
+			}
+
+			return nil, fmt.Errorf("command %s with arguments %#v not registered in redigomock library%s",
+				commandName, args, msg)
 		}
 	}
 

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -184,6 +184,22 @@ func TestDoCommandWithUnexpectedCommand(t *testing.T) {
 	}
 }
 
+func TestDoCommandWithUnexpectedCommandWithSuggestions(t *testing.T) {
+	connection := NewConn()
+	connection.Command("HGETALL", "person:1").ExpectError(fmt.Errorf("simulated error"))
+
+	_, err := RetrievePerson(connection, "X")
+	if err == nil {
+		t.Fatal("Should detect a command not registered!")
+	}
+
+	msg := `command HGETALL with arguments []interface {}{"person:X"} not registered in redigomock library. Possible matches are with the arguments:
+* []interface {}{"person:1"}`
+	if err.Error() != msg {
+		t.Errorf("Unexpected error message: %s", err.Error())
+	}
+}
+
 func TestDoCommandWithoutResponse(t *testing.T) {
 	connection := NewConn()
 


### PR DESCRIPTION
As described by @clawconduce, we could add some suggestions regarding what
arguments could the programmer use to match the specific scenario. This change
could improve error detections during test development.

Resolves #22