### PR TITLE
Reset stats on Clear call

### DIFF
--- a/redigomock.go
+++ b/redigomock.go
@@ -130,6 +130,7 @@ func (c *Conn) removeRelatedCommands(commandName string, args []interface{}) {
 func (c *Conn) Clear() {
 	c.commands = []*Cmd{}
 	c.queue = []queueElement{}
+	c.stats = make(map[cmdHash]int)
 }
 
 // Do looks in the registered commands (via Command function) if someone

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -467,8 +467,8 @@ func TestClear(t *testing.T) {
 		"age":  "32",
 	})
 
-	connection.Send("HGETALL", "person:1")
-	connection.Send("HGETALL", "person:2")
+	connection.Do("HGETALL", "person:1")
+	connection.Do("HGETALL", "person:2")
 
 	connection.Clear()
 
@@ -478,6 +478,10 @@ func TestClear(t *testing.T) {
 
 	if len(connection.queue) > 0 {
 		t.Error("Clear function not clearing the queue")
+	}
+
+	if len(connection.stats) > 0 {
+		t.Error("Clear function not clearing stats")
 	}
 }
 


### PR DESCRIPTION
Fixes a bug when `stats` map is not cleared on `Clear` call.