### PR TITLE
Add ExpectationsWereMet

### DIFF
--- a/command.go
+++ b/command.go
@@ -21,6 +21,7 @@ type Cmd struct {
 	Name      string        // Name of the command
 	Args      []interface{} // Arguments of the command
 	Responses []Response    // Slice of returned responses
+	Called    bool          // State for this command called or not
 }
 
 // cmdHash stores a unique identifier of the command

--- a/redigomock.go
+++ b/redigomock.go
@@ -289,7 +289,7 @@ func (c Conn) ExpectationsWereMet() error {
 
 	if errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
-	} else {
-		return nil
 	}
+
+	return nil
 }

--- a/redigomock.go
+++ b/redigomock.go
@@ -191,7 +191,9 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	}
 
 	response := cmd.Responses[0]
-	cmd.Responses = cmd.Responses[1:]
+	if len(cmd.Responses) > 1 {
+		cmd.Responses = cmd.Responses[1:]
+	}
 	return response.Response, response.Error
 }
 

--- a/redigomock.go
+++ b/redigomock.go
@@ -7,7 +7,6 @@ package redigomock
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"sync"
 )
@@ -269,6 +268,8 @@ func (c Conn) Stats(cmd *Cmd) int {
 	return c.stats[cmd.hash()]
 }
 
+// AllCommandsCalled can guarantee that all commands that was set on unit tests
+// called
 func (c Conn) AllCommandsCalled() error {
 	errMsg := ""
 	for _, cmd := range c.commands {
@@ -278,7 +279,7 @@ func (c Conn) AllCommandsCalled() error {
 	}
 
 	if errMsg != "" {
-		return errors.New(errMsg)
+		return fmt.Errorf("%s", errMsg)
 	} else {
 		return nil
 	}

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -618,3 +618,23 @@ func TestFailCommandOnTransaction(t *testing.T) {
 		t.Errorf("Should have received an error when calling EXEC with a transaction with a command that was not registered")
 	}
 }
+
+func TestAllCommandsCalled(t *testing.T) {
+	connection := NewConn()
+
+	connection.Command("GET", "hello").Expect("world")
+	connection.Command("SET", "hello", "world")
+
+	connection.Do("GET", "hello")
+	// this error is expected
+	err := connection.AllCommandsCalled()
+	if err == nil {
+		t.Fatal("Should have received and error because SET command not called yet")
+	}
+
+	connection.Do("SET", "hello", "world")
+	err = connection.AllCommandsCalled()
+	if err != nil {
+		t.Fatal("Should have no error due to SET already called")
+	}
+}

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -627,14 +627,20 @@ func TestAllCommandsCalled(t *testing.T) {
 
 	connection.Do("GET", "hello")
 	// this error is expected
-	err := connection.AllCommandsCalled()
+	err := connection.ExpectationsWereMet()
 	if err == nil {
 		t.Fatal("Should have received and error because SET command not called yet")
 	}
 
 	connection.Do("SET", "hello", "world")
-	err = connection.AllCommandsCalled()
+	err = connection.ExpectationsWereMet()
 	if err != nil {
 		t.Fatal("Should have no error due to SET already called")
+	}
+
+	connection.Do("DEL", "hello")
+	err = connection.ExpectationsWereMet()
+	if err == nil {
+		t.Fatal("Should have error due to DEL is unexpected")
 	}
 }


### PR DESCRIPTION
ExpectationsWereMet can guarantee that all commands that was set on unit tests called or call of unregistered command can be caught here too. to make sure that the functions tested not violate the 'contract'