### PR TITLE
Expect string slice

### DIFF
--- a/command.go
+++ b/command.go
@@ -69,7 +69,7 @@ func match(commandName string, args []interface{}, cmd *Cmd) bool {
 	return true
 }
 
-// Expect sets a response for this command. Everytime a Do or Receive method
+// Expect sets a response for this command. Every time a Do or Receive method
 // is executed for a registered command this response or error will be
 // returned. Expect call returns a pointer to Cmd struct, so you can chain
 // Expect calls. Chained responses will be returned on subsequent calls
@@ -98,7 +98,7 @@ func (c *Cmd) ExpectError(err error) *Cmd {
 	return c
 }
 
-// ExpectSlice make it easier to expect slice value
+// ExpectSlice makes it easier to expect slice value
 // e.g - HMGET command
 func (c *Cmd) ExpectSlice(resp ...interface{}) *Cmd {
 	response := []interface{}{}

--- a/command.go
+++ b/command.go
@@ -109,6 +109,17 @@ func (c *Cmd) ExpectSlice(resp ...interface{}) *Cmd {
 	return c
 }
 
+// ExpectStringSlice makes it easier to expect a slice of strings, plays nicely
+// with redigo.Strings
+func (c *Cmd) ExpectStringSlice(resp ...string) *Cmd {
+	response := []interface{}{}
+	for _, r := range resp {
+		response = append(response, []byte(r))
+	}
+	c.Responses = append(c.Responses, Response{response, nil})
+	return c
+}
+
 // hash generates a unique identifier for the command
 func (c Cmd) hash() cmdHash {
 	output := c.Name

--- a/command_test.go
+++ b/command_test.go
@@ -329,6 +329,30 @@ func TestExpectSlice(t *testing.T) {
 	}
 }
 
+func TestExpectSliceFromStrings(t *testing.T) {
+	connection := NewConn()
+
+	field1 := "hello"
+	field2 := "redigo"
+	connection.Command("HMGET", "key", "field1", "field2").ExpectStringSlice(field1, field2)
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
+	}
+
+	reply, err := redis.Strings(connection.Do("HMGET", "key", "field1", "field2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reply[0] != field1 {
+		t.Fatalf("reply[0] not %s but %s", field1, reply[0])
+	}
+
+	if reply[1] != field2 {
+		t.Fatalf("reply[1] not %s but %s", field2, reply[1])
+	}
+}
+
 func TestFind(t *testing.T) {
 	connection := NewConn()
 


### PR DESCRIPTION
This simplifies expecting a slice of strings and works with [`redis.Strings`](https://godoc.org/github.com/garyburd/redigo/redis#Strings).