### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,15 @@ go func() {
     rconnSub.ReceiveNow <- true //This sends the "hello" message
 }()
 ```
+
+connections pool
+----------------
+
+```go
+conn := redigomock.NewConn()
+pool := &redis.Pool{
+	// Return the same connection mock for each Get() call.
+	Dial:    func() (redis.Conn, error) { return conn, nil },
+	MaxIdle: 10,
+}
+```


### PR DESCRIPTION
Related to https://github.com/rafaeljusto/redigomock/issues/27

I agree that making a mock for `redis.Pool` may be not a good idea, but at least we could have an example in readme.