### PR TITLE
Add comment on connection pool usage to clarify scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ connections pool
 ----------------
 
 ```go
+// Note you cannot get access to the connection via the pool,
+// the only way is to use this conn variable.
 conn := redigomock.NewConn()
 pool := &redis.Pool{
 	// Return the same connection mock for each Get() call.


### PR DESCRIPTION
If someone wants to access the connection contained within the pool,
the only way is to reuse the connection that is passed to the creation of the pool,
there is no way to get to the connection using pool.Get()