### PR TITLE
Support panic expectation

### DIFF
--- a/command.go
+++ b/command.go
@@ -13,6 +13,7 @@ import (
 type Response struct {
 	Response interface{} // Response to send back when this command/arguments are called
 	Error    error       // Error to send back when this command/arguments are called
+	Panic    interface{} // Panic to throw when this command/arguments are called
 }
 
 // Cmd stores the registered information about a command to return it later
@@ -75,7 +76,7 @@ func match(commandName string, args []interface{}, cmd *Cmd) bool {
 // Expect calls. Chained responses will be returned on subsequent calls
 // matching this commands arguments in FIFO order
 func (c *Cmd) Expect(response interface{}) *Cmd {
-	c.Responses = append(c.Responses, Response{response, nil})
+	c.Responses = append(c.Responses, Response{response, nil, nil})
 	return c
 }
 
@@ -87,14 +88,21 @@ func (c *Cmd) ExpectMap(response map[string]string) *Cmd {
 		values = append(values, []byte(key))
 		values = append(values, []byte(value))
 	}
-	c.Responses = append(c.Responses, Response{values, nil})
+	c.Responses = append(c.Responses, Response{values, nil, nil})
 	return c
 }
 
 // ExpectError allows you to force an error when executing a
 // command/arguments
 func (c *Cmd) ExpectError(err error) *Cmd {
-	c.Responses = append(c.Responses, Response{nil, err})
+	c.Responses = append(c.Responses, Response{nil, err, nil})
+	return c
+}
+
+// ExpectPanic allows you to force a panic when executing a
+// command/arguments
+func (c *Cmd) ExpectPanic(msg interface{}) *Cmd {
+	c.Responses = append(c.Responses, Response{nil, nil, msg})
 	return c
 }
 
@@ -105,7 +113,7 @@ func (c *Cmd) ExpectSlice(resp ...interface{}) *Cmd {
 	for _, r := range resp {
 		response = append(response, r)
 	}
-	c.Responses = append(c.Responses, Response{response, nil})
+	c.Responses = append(c.Responses, Response{response, nil, nil})
 	return c
 }
 
@@ -116,7 +124,7 @@ func (c *Cmd) ExpectStringSlice(resp ...string) *Cmd {
 	for _, r := range resp {
 		response = append(response, []byte(r))
 	}
-	c.Responses = append(c.Responses, Response{response, nil})
+	c.Responses = append(c.Responses, Response{response, nil, nil})
 	return c
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -307,6 +307,26 @@ func TestExpectError(t *testing.T) {
 	}
 }
 
+func TestExpectPanic(t *testing.T) {
+	connection := NewConn()
+
+	connection.Command("HGETALL").ExpectPanic("panic")
+
+	if len(connection.commands) != 1 {
+		t.Fatalf("Did not registered the command. Expected '1' and got '%d'", len(connection.commands))
+	}
+
+	cmd := connection.commands[0]
+
+	if cmd.Responses[0].Panic == nil {
+		t.Fatal("Panic not defined")
+	}
+
+	if cmd.Responses[0].Panic != "panic" {
+		t.Fatal("Storing wrong panic message")
+	}
+}
+
 func TestExpectSlice(t *testing.T) {
 	connection := NewConn()
 

--- a/redigomock.go
+++ b/redigomock.go
@@ -223,6 +223,11 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	if len(cmd.Responses) > 1 {
 		cmd.Responses = cmd.Responses[1:]
 	}
+
+	if response.Panic != nil {
+		panic(response.Panic)
+	}
+
 	return response.Response, response.Error
 }
 

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -77,6 +77,31 @@ func TestDoCommand(t *testing.T) {
 	}
 }
 
+func TestPanickyDoCommand(t *testing.T) {
+
+	panicMsg := "panic-message"
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("Expected a panic to happen")
+		}
+		recoverMsg, ok := r.(string)
+		if ok == false {
+			t.Errorf("Expected the recovered panic value to be a string")
+		}
+		if recoverMsg != panicMsg {
+			t.Errorf("Expected the recovered panic value to be %s", panicMsg)
+		}
+	}()
+
+	connection := NewConn()
+
+	connection.Command("HGETALL", "person:1").ExpectPanic(panicMsg)
+
+	RetrievePerson(connection, "1")
+}
+
 func TestDoCommandMultipleReturnValues(t *testing.T) {
 	connection := NewConn()
 


### PR DESCRIPTION
Having run into a real world situation in which a call to conn.Do is triggering a panic I have augmented the functionality of the library by allowing this to be simulated by  adding a ExpectPanic method to the Cmd struct and a Panic field to the Response struct.