### PR TITLE
Make Do safe for concurrent use even on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - go get github.com/gomodule/redigo/redis
 
 script:
-  - go test
+  - go test -race
 
 notifications:
   email:

--- a/doc.go
+++ b/doc.go
@@ -198,4 +198,8 @@
 // match AnyInt struct created by NewAnyInt() method. AnyInt struct will match
 // any integer passed to redigomock from the tested method. Please see
 // fuzzyMatch.go file for more details.
+//
+// The interface of Conn which matches redigo.Conn is safe for concurrent use,
+// but the mock-only methods and fields, like Command and Errors, should not be
+// accessed concurrently with such calls.
 package redigomock

--- a/doc.go
+++ b/doc.go
@@ -199,7 +199,7 @@
 // any integer passed to redigomock from the tested method. Please see
 // fuzzyMatch.go file for more details.
 //
-// The interface of Conn which matches redigo.Conn is safe for concurrent use,
-// but the mock-only methods and fields, like Command and Errors, should not be
-// accessed concurrently with such calls.
+// The method Conn.Do is safe for concurrent use, but other methods and fields,
+// such as Command and Errors, are generally not and must only be accessed with
+// external synchronization.
 package redigomock

--- a/redigomock.go
+++ b/redigomock.go
@@ -38,6 +38,7 @@ type Conn struct {
 	stats              map[cmdHash]int // Command calls counter
 	statsMut           sync.RWMutex    // Locks the stats so we don't get concurrent map writes
 	Errors             []error         // Storage of all error occured in do functions
+	errorsMut          sync.RWMutex    // Locks Errors to avoid concurrent slice appends
 }
 
 // NewConn returns a new mocked connection. Obviously as we are mocking we
@@ -205,7 +206,9 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 
 			err := fmt.Errorf("command %s with arguments %#v not registered in redigomock library%s",
 				commandName, args, msg)
+			c.errorsMut.Lock()
 			c.Errors = append(c.Errors, err)
+			c.errorsMut.Unlock()
 			return nil, err
 		}
 	}

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -808,3 +808,23 @@ func TestDoCommandWithHandler(t *testing.T) {
 		t.Errorf("unexpected number of notified clients '%d'", clients)
 	}
 }
+
+func TestErrorRace(t *testing.T) {
+	connection := NewConn()
+	n := 100
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			connection.Do("GET", "hello")
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	if len(connection.Errors) != n {
+		t.Errorf("wanted %v errors, got %v", n, len(connection.Errors))
+	}
+}


### PR DESCRIPTION
Previously, if two goroutines called `c.Do` at the same time, and both
were errors (i.e. did not match a mocked command), the changes to
`c.Errors` could conflict.  This is especially visible when running
tests with `-race`, where the runtime will crash rather than clobbering
data.

I also added some documentation of which parts of the library are
currently thread-safe (some would be hard to fix without breaking
compatibility) and enabled the race detector in tests to prove it.