### PR TITLE
Fix race detector errors from concurrent Do calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - go get github.com/gomodule/redigo/redis
 
 script:
-  - go test
+  - go test -race
 
 notifications:
   email:

--- a/redigomock.go
+++ b/redigomock.go
@@ -214,7 +214,7 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	c.stats[cmd.hash()]++
 	c.statsMut.Unlock()
 
-	cmd.Called = true
+	cmd.calledOnce.Do(func() { cmd.Called = true })
 	if len(cmd.Responses) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
I came across two races from concurrent calls to Do.  It's not obvious
to me whether either can actually cause problems in practice, but they
trip the race detector, and from my reading of the Go memory model [1]
may have undefined behavior.  In any case, as [1] says, "If you must
read the rest of this document to understand the behavior of your
program, you are being too clever. Don't be clever.".  Plus, running the
race detector is a nice way to improve confidence that the program is in
fact correct.

The first race is between `cmd.hash()` and `cmd.Called = true`.  You
might think: those are different variables, why is that a race?  But
`cmd.hash` is a *value* receiver, which means that it copies the
receiver.  So that does a read on `cmd.Called`, even though `cmd.hash`
doesn't use `cmd.Called` at all.  (In principle the compiler could
optimize the race out, but in practice it doesn't.)  This is trivial to
fix: just make `cmd.hash` a pointer receiver.

The second race is between two copies of `cmd.Called = true`.  I can't
find a clear reference on whether this is considered safe, but [1]
doesn't seem to say so.  (In particular, a later assertion about the
value of `cmd.Called` is not guaranteed to observe either write, because
it can't guarantee that the other write didn't happen later.  A coworker
tells me that this is definitely not guaranteed by C++, which is also
suggestive.)  In this case, I now use a `sync.Once` to initialze it.

The added test that runs a bunch of concurrent calls to `Do` reproduces
both issues when run with the race detector.

[1] https://golang.org/ref/mem