### PR TITLE
Fix a ton of races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - go get github.com/gomodule/redigo/redis
 
 script:
-  - go test
+  - go test -race
 
 notifications:
   email:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 Ahmad Muzakki      - @ahmadmuzakki29
 Artem Krylysov     - @akrylysov
+Ben Kraft          - @benjaminjkraft
 Charles Law        - @clawconduce
 Damien Mathieu     - @dmathieu
 Drew Landis        - @drewlandis

--- a/command.go
+++ b/command.go
@@ -9,11 +9,11 @@ import (
 	"reflect"
 )
 
-// Response struct that represents single response from `Do` call
-type Response struct {
-	Response interface{} // Response to send back when this command/arguments are called
-	Error    error       // Error to send back when this command/arguments are called
-	Panic    interface{} // Panic to throw when this command/arguments are called
+// response struct that represents single response from `Do` call.
+type response struct {
+	response interface{} // Response to send back when this command/arguments are called
+	err      error       // Error to send back when this command/arguments are called
+	panicVal interface{} // Panic to throw when this command/arguments are called
 }
 
 // ResponseHandler dynamic handles the response for the provided arguments.
@@ -22,10 +22,10 @@ type ResponseHandler func(args []interface{}) (interface{}, error)
 // Cmd stores the registered information about a command to return it later
 // when request by a command execution
 type Cmd struct {
-	Name      string        // Name of the command
-	Args      []interface{} // Arguments of the command
-	Responses []Response    // Slice of returned responses
-	Called    bool          // State for this command called or not
+	name      string        // Name of the command
+	args      []interface{} // Arguments of the command
+	responses []response    // Slice of returned responses
+	called    bool          // State for this command called or not
 }
 
 // cmdHash stores a unique identifier of the command
@@ -33,19 +33,19 @@ type cmdHash string
 
 // equal verify if a command/arguments is related to a registered command
 func equal(commandName string, args []interface{}, cmd *Cmd) bool {
-	if commandName != cmd.Name || len(args) != len(cmd.Args) {
+	if commandName != cmd.name || len(args) != len(cmd.args) {
 		return false
 	}
 
-	for pos := range cmd.Args {
-		if implementsFuzzy(cmd.Args[pos]) && implementsFuzzy(args[pos]) {
-			if reflect.TypeOf(cmd.Args[pos]) != reflect.TypeOf(args[pos]) {
+	for pos := range cmd.args {
+		if implementsFuzzy(cmd.args[pos]) && implementsFuzzy(args[pos]) {
+			if reflect.TypeOf(cmd.args[pos]) != reflect.TypeOf(args[pos]) {
 				return false
 			}
-		} else if implementsFuzzy(cmd.Args[pos]) || implementsFuzzy(args[pos]) {
+		} else if implementsFuzzy(cmd.args[pos]) || implementsFuzzy(args[pos]) {
 			return false
 		} else {
-			if reflect.DeepEqual(cmd.Args[pos], args[pos]) == false {
+			if reflect.DeepEqual(cmd.args[pos], args[pos]) == false {
 				return false
 			}
 		}
@@ -56,19 +56,18 @@ func equal(commandName string, args []interface{}, cmd *Cmd) bool {
 // match check if provided arguments can be matched with any registered
 // commands
 func match(commandName string, args []interface{}, cmd *Cmd) bool {
-	if commandName != cmd.Name || len(args) != len(cmd.Args) {
+	if commandName != cmd.name || len(args) != len(cmd.args) {
 		return false
 	}
 
-	for pos := range cmd.Args {
-		if implementsFuzzy(cmd.Args[pos]) {
-			if cmd.Args[pos].(FuzzyMatcher).Match(args[pos]) == false {
+	for pos := range cmd.args {
+		if implementsFuzzy(cmd.args[pos]) {
+			if cmd.args[pos].(FuzzyMatcher).Match(args[pos]) == false {
 				return false
 			}
-		} else if reflect.DeepEqual(cmd.Args[pos], args[pos]) == false {
+		} else if reflect.DeepEqual(cmd.args[pos], args[pos]) == false {
 			return false
 		}
-
 	}
 	return true
 }
@@ -78,71 +77,76 @@ func match(commandName string, args []interface{}, cmd *Cmd) bool {
 // returned. Expect call returns a pointer to Cmd struct, so you can chain
 // Expect calls. Chained responses will be returned on subsequent calls
 // matching this commands arguments in FIFO order
-func (c *Cmd) Expect(response interface{}) *Cmd {
-	c.Responses = append(c.Responses, Response{response, nil, nil})
+func (c *Cmd) Expect(resp interface{}) *Cmd {
+	c.responses = append(c.responses, response{resp, nil, nil})
 	return c
 }
 
 // ExpectMap works in the same way of the Expect command, but has a key/value
 // input to make it easier to build test environments
-func (c *Cmd) ExpectMap(response map[string]string) *Cmd {
+func (c *Cmd) ExpectMap(resp map[string]string) *Cmd {
 	var values []interface{}
-	for key, value := range response {
+	for key, value := range resp {
 		values = append(values, []byte(key))
 		values = append(values, []byte(value))
 	}
-	c.Responses = append(c.Responses, Response{values, nil, nil})
+	c.responses = append(c.responses, response{values, nil, nil})
 	return c
 }
 
 // ExpectError allows you to force an error when executing a
 // command/arguments
 func (c *Cmd) ExpectError(err error) *Cmd {
-	c.Responses = append(c.Responses, Response{nil, err, nil})
+	c.responses = append(c.responses, response{nil, err, nil})
 	return c
 }
 
 // ExpectPanic allows you to force a panic when executing a
 // command/arguments
 func (c *Cmd) ExpectPanic(msg interface{}) *Cmd {
-	c.Responses = append(c.Responses, Response{nil, nil, msg})
+	c.responses = append(c.responses, response{nil, nil, msg})
 	return c
 }
 
 // ExpectSlice makes it easier to expect slice value
 // e.g - HMGET command
 func (c *Cmd) ExpectSlice(resp ...interface{}) *Cmd {
-	response := []interface{}{}
+	ifaces := []interface{}{}
 	for _, r := range resp {
-		response = append(response, r)
+		ifaces = append(ifaces, r)
 	}
-	c.Responses = append(c.Responses, Response{response, nil, nil})
+	c.responses = append(c.responses, response{ifaces, nil, nil})
 	return c
 }
 
 // ExpectStringSlice makes it easier to expect a slice of strings, plays nicely
 // with redigo.Strings
 func (c *Cmd) ExpectStringSlice(resp ...string) *Cmd {
-	response := []interface{}{}
+	ifaces := []interface{}{}
 	for _, r := range resp {
-		response = append(response, []byte(r))
+		ifaces = append(ifaces, []byte(r))
 	}
-	c.Responses = append(c.Responses, Response{response, nil, nil})
+	c.responses = append(c.responses, response{ifaces, nil, nil})
 	return c
 }
 
 // Handle registers a function to handle the incoming arguments, generating an
 // on-the-fly response.
 func (c *Cmd) Handle(fn ResponseHandler) *Cmd {
-	c.Responses = append(c.Responses, Response{fn, nil, nil})
+	c.responses = append(c.responses, response{fn, nil, nil})
 	return c
 }
 
 // hash generates a unique identifier for the command
 func (c Cmd) hash() cmdHash {
-	output := c.Name
-	for _, arg := range c.Args {
+	output := c.name
+	for _, arg := range c.args {
 		output += fmt.Sprintf("%v", arg)
 	}
 	return cmdHash(output)
+}
+
+// Called returns true if the command-mock was ever called.
+func (c *Cmd) Called() bool {
+	return c.called
 }

--- a/command_test.go
+++ b/command_test.go
@@ -22,30 +22,30 @@ func TestCommand(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Name != "HGETALL" {
+	if cmd.name != "HGETALL" {
 		t.Error("Wrong name defined for command")
 	}
 
-	if len(cmd.Args) != 3 {
+	if len(cmd.args) != 3 {
 		t.Fatal("Wrong arguments defined for command")
 	}
 
-	arg := cmd.Args[0].(string)
+	arg := cmd.args[0].(string)
 	if arg != "a" {
 		t.Errorf("Wrong argument defined for command. Expected 'a' and got '%s'", arg)
 	}
 
-	arg = cmd.Args[1].(string)
+	arg = cmd.args[1].(string)
 	if arg != "b" {
 		t.Errorf("Wrong argument defined for command. Expected 'b' and got '%s'", arg)
 	}
 
-	arg = cmd.Args[2].(string)
+	arg = cmd.args[2].(string)
 	if arg != "c" {
 		t.Errorf("Wrong argument defined for command. Expected 'c' and got '%s'", arg)
 	}
 
-	if len(cmd.Responses) != 0 {
+	if len(cmd.responses) != 0 {
 		t.Error("Response defined without any call")
 	}
 }
@@ -57,98 +57,98 @@ func TestScript(t *testing.T) {
 	h.Write(scriptData)
 	sha1sum := hex.EncodeToString(h.Sum(nil))
 
-	connection.Script(scriptData, 0)                           //0
-	connection.Script(scriptData, 0, "value1")                 //1
-	connection.Script(scriptData, 1, "key1")                   //2
-	connection.Script(scriptData, 1, "key1", "value1")         //3
-	connection.Script(scriptData, 2, "key1", "key2", "value1") //4
+	connection.Script(scriptData, 0)                           // 0
+	connection.Script(scriptData, 0, "value1")                 // 1
+	connection.Script(scriptData, 1, "key1")                   // 2
+	connection.Script(scriptData, 1, "key1", "value1")         // 3
+	connection.Script(scriptData, 2, "key1", "key2", "value1") // 4
 
 	if len(connection.commands) != 5 {
 		t.Fatalf("Did not register the commands. Expected '5' and got '%d'", len(connection.commands))
 	}
 
-	if connection.commands[0].Name != "EVALSHA" {
+	if connection.commands[0].name != "EVALSHA" {
 		t.Error("Wrong name defined for command")
 	}
 
-	if len(connection.commands[0].Args) != 2 {
-		t.Errorf("Wrong arguments defined for command %v", connection.commands[0].Args)
+	if len(connection.commands[0].args) != 2 {
+		t.Errorf("Wrong arguments defined for command %v", connection.commands[0].args)
 	}
 
-	if len(connection.commands[1].Args) != 3 {
+	if len(connection.commands[1].args) != 3 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(connection.commands[2].Args) != 3 {
+	if len(connection.commands[2].args) != 3 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(connection.commands[3].Args) != 4 {
+	if len(connection.commands[3].args) != 4 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	if len(connection.commands[4].Args) != 5 {
+	if len(connection.commands[4].args) != 5 {
 		t.Error("Wrong arguments defined for command")
 	}
 
-	//Script(scriptData, 0)
-	arg := connection.commands[0].Args[0].(string)
+	// Script(scriptData, 0)
+	arg := connection.commands[0].args[0].(string)
 	if arg != sha1sum {
 		t.Errorf("Wrong argument defined for command. Expected '%s' and got '%s'", sha1sum, arg)
 	}
-	argInt := connection.commands[0].Args[1].(int)
+	argInt := connection.commands[0].args[1].(int)
 	if argInt != 0 {
 		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
 	}
 
-	//Script(scriptData, 0, "value1")
-	argInt = connection.commands[1].Args[1].(int)
+	// Script(scriptData, 0, "value1")
+	argInt = connection.commands[1].args[1].(int)
 	if argInt != 0 {
 		t.Errorf("Wrong argument defined for command. Expected '0' and got '%v'", argInt)
 	}
-	arg = connection.commands[1].Args[2].(string)
+	arg = connection.commands[1].args[2].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 
-	//Script(scriptData, 1, "key1")
-	argInt = connection.commands[2].Args[1].(int)
+	// Script(scriptData, 1, "key1")
+	argInt = connection.commands[2].args[1].(int)
 	if argInt != 1 {
 		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
 	}
-	arg = connection.commands[2].Args[2].(string)
+	arg = connection.commands[2].args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
 
-	//Script(scriptData, 1, "key1", "value1")
-	argInt = connection.commands[3].Args[1].(int)
+	// Script(scriptData, 1, "key1", "value1")
+	argInt = connection.commands[3].args[1].(int)
 	if argInt != 1 {
 		t.Errorf("Wrong argument defined for command. Expected '1' and got '%v'", argInt)
 	}
-	arg = connection.commands[3].Args[2].(string)
+	arg = connection.commands[3].args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
-	arg = connection.commands[3].Args[3].(string)
+	arg = connection.commands[3].args[3].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
 
-	//Script(scriptData, 2, "key1", "key2", "value1")
-	argInt = connection.commands[4].Args[1].(int)
+	// Script(scriptData, 2, "key1", "key2", "value1")
+	argInt = connection.commands[4].args[1].(int)
 	if argInt != 2 {
 		t.Errorf("Wrong argument defined for command. Expected '2' and got '%v'", argInt)
 	}
-	arg = connection.commands[4].Args[2].(string)
+	arg = connection.commands[4].args[2].(string)
 	if arg != "key1" {
 		t.Errorf("Wrong argument defined for command. Expected 'key1' and got '%s'", arg)
 	}
-	arg = connection.commands[4].Args[3].(string)
+	arg = connection.commands[4].args[3].(string)
 	if arg != "key2" {
 		t.Errorf("Wrong argument defined for command. Expected 'key2' and got '%s'", arg)
 	}
-	arg = connection.commands[4].Args[4].(string)
+	arg = connection.commands[4].args[4].(string)
 	if arg != "value1" {
 		t.Errorf("Wrong argument defined for command. Expected 'value1' and got '%s'", arg)
 	}
@@ -164,15 +164,15 @@ func TestGenericCommand(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Name != "HGETALL" {
+	if cmd.name != "HGETALL" {
 		t.Error("Wrong name defined for command")
 	}
 
-	if len(cmd.Args) > 0 {
+	if len(cmd.args) > 0 {
 		t.Error("Arguments defined for command when they shouldn't")
 	}
 
-	if len(cmd.Responses) != 0 {
+	if len(cmd.responses) != 0 {
 		t.Error("Response defined without any call")
 	}
 }
@@ -187,11 +187,11 @@ func TestExpect(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Responses[0].Response == nil {
+	if cmd.responses[0].response == nil {
 		t.Fatal("Response not defined")
 	}
 
-	value, ok := cmd.Responses[0].Response.(string)
+	value, ok := cmd.responses[0].response.(string)
 	if !ok {
 		t.Fatal("Not storing response in the correct type")
 	}
@@ -214,11 +214,11 @@ func TestExpectMap(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Responses[0].Response == nil {
+	if cmd.responses[0].response == nil {
 		t.Fatal("Response not defined")
 	}
 
-	values, ok := cmd.Responses[0].Response.([]interface{})
+	values, ok := cmd.responses[0].response.([]interface{})
 	if !ok {
 		t.Fatal("Not storing response in the correct type")
 	}
@@ -235,7 +235,6 @@ func TestExpectMap(t *testing.T) {
 				t.Errorf("Changing the response content. Expected '%s' and got '%s'",
 					expected[i], string(value))
 			}
-
 		} else {
 			t.Error("Not storing the map content in byte format")
 		}
@@ -259,11 +258,11 @@ func TestExpectMapReplace(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Responses[0].Response == nil {
+	if cmd.responses[0].response == nil {
 		t.Fatal("Response not defined")
 	}
 
-	values, ok := cmd.Responses[0].Response.([]interface{})
+	values, ok := cmd.responses[0].response.([]interface{})
 	if !ok {
 		t.Fatal("Not storing response in the correct type")
 	}
@@ -280,7 +279,6 @@ func TestExpectMapReplace(t *testing.T) {
 				t.Errorf("Changing the response content. Expected '%s' and got '%s'",
 					expected[i], string(value))
 			}
-
 		} else {
 			t.Error("Not storing the map content in byte format")
 		}
@@ -298,11 +296,11 @@ func TestExpectError(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Responses[0].Error == nil {
+	if cmd.responses[0].err == nil {
 		t.Fatal("Error not defined")
 	}
 
-	if cmd.Responses[0].Error.Error() != "error" {
+	if cmd.responses[0].err.Error() != "error" {
 		t.Fatal("Storing wrong error")
 	}
 }
@@ -318,11 +316,11 @@ func TestExpectPanic(t *testing.T) {
 
 	cmd := connection.commands[0]
 
-	if cmd.Responses[0].Panic == nil {
+	if cmd.responses[0].panicVal == nil {
 		t.Fatal("Panic not defined")
 	}
 
-	if cmd.Responses[0].Panic != "panic" {
+	if cmd.responses[0].panicVal != "panic" {
 		t.Fatal("Storing wrong panic message")
 	}
 }
@@ -402,9 +400,9 @@ func TestRemoveRelatedCommands(t *testing.T) {
 	connection.Command("HGETALL", "a", "b", "c") // 1
 	connection.Command("HGETALL", "a", "b", "c") // omit
 	connection.Command("HGETALL", "c", "b", "a") // 2
-	connection.Command("HGETALL")                //3
+	connection.Command("HGETALL")                // 3
 	connection.Command("HSETALL", "c", "b", "a") // 4
-	connection.Command("HSETALL")                //5
+	connection.Command("HSETALL")                // 5
 
 	if len(connection.commands) != 5 {
 		t.Errorf("Not removing related commands. Expected '5' and got '%d'", len(connection.commands))
@@ -419,43 +417,43 @@ func TestMatch(t *testing.T) {
 		equal       bool
 	}{
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b", "c"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", "b", "c"}},
 			commandName: "HGETALL",
 			args:        []interface{}{"a", "b", "c"},
 			equal:       true,
 		},
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", []byte("abcdef"), "c"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", []byte("abcdef"), "c"}},
 			commandName: "HGETALL",
 			args:        []interface{}{"a", []byte("abcdef"), "c"},
 			equal:       true,
 		},
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b", "c"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", "b", "c"}},
 			commandName: "HGETALL",
 			args:        []interface{}{"c", "b", "a"},
 			equal:       false,
 		},
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b", "c"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", "b", "c"}},
 			commandName: "HGETALL",
 			args:        []interface{}{"a", "b"},
 			equal:       false,
 		},
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", "b"}},
 			commandName: "HGETALL",
 			args:        []interface{}{"a", "b", "c"},
 			equal:       false,
 		},
 		{
-			cmd:         &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b", "c"}},
+			cmd:         &Cmd{name: "HGETALL", args: []interface{}{"a", "b", "c"}},
 			commandName: "HSETALL",
 			args:        []interface{}{"a", "b", "c"},
 			equal:       false,
 		},
 		{
-			cmd:         &Cmd{Name: "HSETALL", Args: nil},
+			cmd:         &Cmd{name: "HSETALL", args: nil},
 			commandName: "HSETALL",
 			args:        nil,
 			equal:       true,
@@ -466,7 +464,6 @@ func TestMatch(t *testing.T) {
 		e := match(item.commandName, item.args, item.cmd)
 		if e != item.equal && item.equal {
 			t.Errorf("Expected commands to be equal for data item '%d'", i)
-
 		} else if e != item.equal && !item.equal {
 			t.Errorf("Expected commands to be different for data item '%d'", i)
 		}
@@ -479,11 +476,11 @@ func TestHash(t *testing.T) {
 		expected cmdHash
 	}{
 		{
-			cmd:      &Cmd{Name: "HGETALL", Args: []interface{}{"a", "b", "c"}},
+			cmd:      &Cmd{name: "HGETALL", args: []interface{}{"a", "b", "c"}},
 			expected: cmdHash("HGETALLabc"),
 		},
 		{
-			cmd:      &Cmd{Name: "HGETALL", Args: []interface{}{"a", []byte("abcdef"), "c"}},
+			cmd:      &Cmd{name: "HGETALL", args: []interface{}{"a", []byte("abcdef"), "c"}},
 			expected: "HGETALLa[97 98 99 100 101 102]c",
 		},
 	}

--- a/doc.go
+++ b/doc.go
@@ -198,4 +198,8 @@
 // match AnyInt struct created by NewAnyInt() method. AnyInt struct will match
 // any integer passed to redigomock from the tested method. Please see
 // fuzzyMatch.go file for more details.
+//
+// The interface of Conn which matches redigo.Conn is safe for concurrent use,
+// but the mock-only methods and fields, like Command and Errors, should not be
+// accessed concurrently with such calls.
 package redigomock

--- a/fuzzy_match_test.go
+++ b/fuzzy_match_test.go
@@ -3,7 +3,7 @@ package redigomock
 import "testing"
 
 func TestFuzzyCommandMatchAnyInt(t *testing.T) {
-	var fuzzyCommandTestInput = []struct {
+	fuzzyCommandTestInput := []struct {
 		arguments []interface{}
 		match     bool
 	}{
@@ -20,8 +20,8 @@ func TestFuzzyCommandMatchAnyInt(t *testing.T) {
 	}
 
 	command := Cmd{
-		Name: "TEST_COMMAND",
-		Args: []interface{}{"Test string", NewAnyInt()},
+		name: "TEST_COMMAND",
+		args: []interface{}{"Test string", NewAnyInt()},
 	}
 
 	for pos, element := range fuzzyCommandTestInput {
@@ -33,7 +33,7 @@ func TestFuzzyCommandMatchAnyInt(t *testing.T) {
 }
 
 func TestFuzzyCommandMatchAnyDouble(t *testing.T) {
-	var fuzzyCommandTestInput = []struct {
+	fuzzyCommandTestInput := []struct {
 		arguments []interface{}
 		match     bool
 	}{
@@ -50,8 +50,8 @@ func TestFuzzyCommandMatchAnyDouble(t *testing.T) {
 	}
 
 	command := Cmd{
-		Name: "TEST_COMMAND",
-		Args: []interface{}{"Test string", NewAnyDouble()},
+		name: "TEST_COMMAND",
+		args: []interface{}{"Test string", NewAnyDouble()},
 	}
 
 	for pos, element := range fuzzyCommandTestInput {
@@ -63,7 +63,7 @@ func TestFuzzyCommandMatchAnyDouble(t *testing.T) {
 }
 
 func TestFuzzyCommandMatchAnyData(t *testing.T) {
-	var fuzzyCommandTestInput = []struct {
+	fuzzyCommandTestInput := []struct {
 		arguments []interface{}
 		match     bool
 	}{
@@ -75,8 +75,8 @@ func TestFuzzyCommandMatchAnyData(t *testing.T) {
 	}
 
 	command := Cmd{
-		Name: "TEST_COMMAND",
-		Args: []interface{}{"Test string", NewAnyData()},
+		name: "TEST_COMMAND",
+		args: []interface{}{"Test string", NewAnyData()},
 	}
 
 	for pos, element := range fuzzyCommandTestInput {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/rafaeljusto/redigomock/v2
+
+go 1.15
+
+require (
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/rafaeljusto/redigomock v2.4.0+incompatible // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/rafaeljusto/redigomock v2.4.0+incompatible h1:d7uo5MVINMxnRr20MxbgDkmZ8QRfevjOVgEa4n0OZyY=
+github.com/rafaeljusto/redigomock v2.4.0+incompatible/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=

--- a/redigomock.go
+++ b/redigomock.go
@@ -23,9 +23,11 @@ type replyElement struct {
 }
 
 // Conn is the struct that can be used where you inject the redigo.Conn on
-// your project
+// your project.
+//
+// The fields of Conn should not be modified after first use.  (Sending to
+// ReceiveNow is safe.)
 type Conn struct {
-	SubResponses       []Response      // Queue responses for PubSub
 	ReceiveWait        bool            // When set to true, Receive method will wait for a value in ReceiveNow channel to proceed, this is useful in a PubSub scenario
 	ReceiveNow         chan bool       // Used to lock Receive method to simulate a PubSub scenario
 	CloseMock          func() error    // Mock the redigo Close method
@@ -35,9 +37,10 @@ type Conn struct {
 	commands           []*Cmd          // Slice that stores all registered commands for each connection
 	queue              []queueElement  // Slice that stores all queued commands for each connection
 	replies            []replyElement  // Slice that stores all queued replies
+	subResponses       []response      // Queue responses for PubSub
 	stats              map[cmdHash]int // Command calls counter
 	statsMut           sync.RWMutex    // Locks the stats so we don't get concurrent map writes
-	Errors             []error         // Storage of all error occured in do functions
+	errors             []error         // Storage of all error occured in do functions
 }
 
 // NewConn returns a new mocked connection. Obviously as we are mocking we
@@ -72,8 +75,8 @@ func (c *Conn) Err() error {
 // you can set the response or error
 func (c *Conn) Command(commandName string, args ...interface{}) *Cmd {
 	cmd := &Cmd{
-		Name: commandName,
-		Args: args,
+		name: commandName,
+		args: args,
 	}
 	c.removeRelatedCommands(commandName, args)
 	c.commands = append(c.commands, cmd)
@@ -101,7 +104,7 @@ func (c *Conn) Script(scriptData []byte, keyCount int, args ...interface{}) *Cmd
 // generic commands before throwing an error
 func (c *Conn) GenericCommand(commandName string) *Cmd {
 	cmd := &Cmd{
-		Name: commandName,
+		name: commandName,
 	}
 
 	c.removeRelatedCommands(commandName, nil)
@@ -195,17 +198,17 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 		if cmd = c.find(commandName, nil); cmd == nil {
 			var msg string
 			for _, regCmd := range c.commands {
-				if commandName == regCmd.Name {
+				if commandName == regCmd.name {
 					if len(msg) == 0 {
 						msg = ". Possible matches are with the arguments:"
 					}
-					msg += fmt.Sprintf("\n* %#v", regCmd.Args)
+					msg += fmt.Sprintf("\n* %#v", regCmd.args)
 				}
 			}
 
 			err := fmt.Errorf("command %s with arguments %#v not registered in redigomock library%s",
 				commandName, args, msg)
-			c.Errors = append(c.Errors, err)
+			c.errors = append(c.errors, err)
 			return nil, err
 		}
 	}
@@ -214,24 +217,24 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	c.stats[cmd.hash()]++
 	c.statsMut.Unlock()
 
-	cmd.Called = true
-	if len(cmd.Responses) == 0 {
+	cmd.called = true
+	if len(cmd.responses) == 0 {
 		return nil, nil
 	}
 
-	response := cmd.Responses[0]
-	if len(cmd.Responses) > 1 {
-		cmd.Responses = cmd.Responses[1:]
+	response := cmd.responses[0]
+	if len(cmd.responses) > 1 {
+		cmd.responses = cmd.responses[1:]
 	}
 
-	if response.Panic != nil {
-		panic(response.Panic)
+	if response.panicVal != nil {
+		panic(response.panicVal)
 	}
 
-	if handler, ok := response.Response.(ResponseHandler); ok {
+	if handler, ok := response.response.(ResponseHandler); ok {
 		return handler(args)
 	}
-	return response.Response, response.Error
+	return response.response, response.err
 }
 
 // DoWithTimeout is a helper function for Do call to satisfy the ConnWithTimeout
@@ -275,9 +278,9 @@ func (c *Conn) Flush() error {
 // AddSubscriptionMessage register a response to be returned by the receive
 // call.
 func (c *Conn) AddSubscriptionMessage(msg interface{}) {
-	resp := Response{}
-	resp.Response = msg
-	c.SubResponses = append(c.SubResponses, resp)
+	resp := response{}
+	resp.response = msg
+	c.subResponses = append(c.subResponses, resp)
 }
 
 // Receive will process the queue created by the Send method, only one item
@@ -288,9 +291,9 @@ func (c *Conn) Receive() (reply interface{}, err error) {
 	}
 
 	if len(c.queue) == 0 && len(c.replies) == 0 {
-		if len(c.SubResponses) > 0 {
-			reply, err = c.SubResponses[0].Response, c.SubResponses[0].Error
-			c.SubResponses = c.SubResponses[1:]
+		if len(c.subResponses) > 0 {
+			reply, err = c.subResponses[0].response, c.subResponses[0].err
+			c.subResponses = c.subResponses[1:]
 			return
 		}
 		return nil, fmt.Errorf("no more items")
@@ -324,13 +327,13 @@ func (c *Conn) Stats(cmd *Cmd) int {
 // called or call of unregistered command can be caught here too
 func (c *Conn) ExpectationsWereMet() error {
 	errMsg := ""
-	for _, err := range c.Errors {
+	for _, err := range c.errors {
 		errMsg = fmt.Sprintf("%s%s\n", errMsg, err.Error())
 	}
 
 	for _, cmd := range c.commands {
-		if !cmd.Called {
-			errMsg = fmt.Sprintf("%sCommand %s with arguments %#v expected but never called.\n", errMsg, cmd.Name, cmd.Args)
+		if !cmd.called {
+			errMsg = fmt.Sprintf("%sCommand %s with arguments %#v expected but never called.\n", errMsg, cmd.name, cmd.args)
 		}
 	}
 
@@ -339,4 +342,13 @@ func (c *Conn) ExpectationsWereMet() error {
 	}
 
 	return nil
+}
+
+// Errors returns any errors that this connection returned in lieu of a valid
+// mock.
+func (c *Conn) Errors() []error {
+	// Return a copy of c.errors, in case caller wants to mutate it
+	ret := make([]error, len(c.errors))
+	copy(ret, c.errors)
+	return ret
 }

--- a/redigomock.go
+++ b/redigomock.go
@@ -217,14 +217,9 @@ func (c *Conn) do(commandName string, args ...interface{}) (reply interface{}, e
 	c.stats[cmd.hash()]++
 	c.statsMut.Unlock()
 
-	cmd.called = true
-	if len(cmd.responses) == 0 {
+	response := cmd.getResponse()
+	if response == nil {
 		return nil, nil
-	}
-
-	response := cmd.responses[0]
-	if len(cmd.responses) > 1 {
-		cmd.responses = cmd.responses[1:]
 	}
 
 	if response.panicVal != nil {
@@ -332,7 +327,7 @@ func (c *Conn) ExpectationsWereMet() error {
 	}
 
 	for _, cmd := range c.commands {
-		if !cmd.called {
+		if !cmd.Called() {
 			errMsg = fmt.Sprintf("%sCommand %s with arguments %#v expected but never called.\n", errMsg, cmd.name, cmd.args)
 		}
 	}

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -831,3 +831,23 @@ func TestDoCommandWithHandler(t *testing.T) {
 		t.Errorf("unexpected number of notified clients '%d'", clients)
 	}
 }
+
+func TestErrorRace(t *testing.T) {
+	connection := NewConn()
+	n := 100
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			connection.Do("GET", "hello")
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	if len(connection.Errors()) != n {
+		t.Errorf("wanted %v errors, got %v", n, len(connection.Errors()))
+	}
+}

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
-var _ redis.Conn = &Conn{}
-var _ redis.ConnWithTimeout = &Conn{}
+var (
+	_ redis.Conn            = &Conn{}
+	_ redis.ConnWithTimeout = &Conn{}
+)
 
 type Person struct {
 	Name string `redis:"name"`
@@ -78,7 +80,6 @@ func TestDoCommand(t *testing.T) {
 }
 
 func TestPanickyDoCommand(t *testing.T) {
-
 	panicMsg := "panic-message"
 
 	defer func() {
@@ -327,7 +328,6 @@ func TestDoEmptyFlushPipeline(t *testing.T) {
 			t.Errorf("Didn't receive expected: %s != %s", cmds[i].val, val)
 		}
 	}
-
 }
 
 func TestSendFlushReceive(t *testing.T) {
@@ -466,8 +466,8 @@ func TestPubSub(t *testing.T) {
 		})
 	}
 
-	if len(conn.SubResponses) != 4 {
-		t.Errorf("unexpected number of sub-responses, expected '%d', got '%d'", 4, len(conn.SubResponses))
+	if len(conn.subResponses) != 4 {
+		t.Errorf("unexpected number of sub-responses, expected '%d', got '%d'", 4, len(conn.subResponses))
 	}
 
 	// function to trigger a new pub/sub message received from the redis server


### PR DESCRIPTION
This PR makes a bunch of API breaks in order to actually make the library more generally safe for concurrent use.  This would moot #59, and #61, and comes from discussion there and in #60.  See individual commits for the changes.

Fixes #60.