### PR TITLE
Implement ConnWithContext interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/rafaeljusto/redigomock/v3
 
 go 1.15
 
-require github.com/gomodule/redigo v1.8.3
+require github.com/gomodule/redigo v1.8.6

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
-github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/gomodule/redigo v1.8.6 h1:h7kHSqUl2kxeaQtVslsfUCPJ1oz2pxcyzLy4zezIzPw=
+github.com/gomodule/redigo v1.8.6/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/redigomock.go
+++ b/redigomock.go
@@ -5,6 +5,7 @@
 package redigomock
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
@@ -251,6 +252,12 @@ func (c *Conn) DoWithTimeout(readTimeout time.Duration, cmd string, args ...inte
 	return c.Do(cmd, args...)
 }
 
+// DoContext is a helper function for Do call to satisfy the ConnWithContext
+// interface.
+func (c *Conn) DoContext(ctx context.Context, cmd string, args ...interface{}) (reply interface{}, err error) {
+	return c.Do(cmd, args...)
+}
+
 // Send stores the command and arguments to be executed later (by the Receive
 // function) in a first-come first-served order
 func (c *Conn) Send(commandName string, args ...interface{}) error {
@@ -337,6 +344,12 @@ func (c *Conn) Receive() (reply interface{}, err error) {
 // ReceiveWithTimeout is a helper function for Receive call to satisfy the
 // ConnWithTimeout interface.
 func (c *Conn) ReceiveWithTimeout(timeout time.Duration) (interface{}, error) {
+	return c.Receive()
+}
+
+// ReceiveContext is a helper function for Receive call to satisfy the
+// ConnWithContext interface.
+func (c *Conn) ReceiveContext(ctx context.Context) (reply interface{}, err error) {
 	return c.Receive()
 }
 

--- a/redigomock_test.go
+++ b/redigomock_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	_ redis.Conn            = &Conn{}
 	_ redis.ConnWithTimeout = &Conn{}
+	_ redis.ConnWithContext = &Conn{}
 )
 
 type Person struct {


### PR DESCRIPTION
In https://github.com/gomodule/redigo/pull/537 (v1.8.6), redigo added a new `ConnWithContext` interface. This PR implements that interface so it can be mocked.