### PR TITLE
Update license GPL -> MIT in .go files too

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Rafael Dantas Justo. All rights reserved.
-// Use of this source code is governed by a GPL
+// Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
 package redigomock

--- a/command_test.go
+++ b/command_test.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Rafael Dantas Justo. All rights reserved.
-// Use of this source code is governed by a GPL
+// Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
 package redigomock

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2014 Rafael Dantas Justo. All rights reserved.
 
-// Use of this source code is governed by a GPL
+// Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
 // Package redigomock is a mock for redigo library (redis client)

--- a/redigomock.go
+++ b/redigomock.go
@@ -1,5 +1,5 @@
 // Copyright 2014 Rafael Dantas Justo. All rights reserved.
-// Use of this source code is governed by a GPL
+// Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
 package redigomock


### PR DESCRIPTION
License was changed from GPL to MIT in 8b8b83f41892e391799562cf9bd9efe754c8383f, however some files still retain the wording "this source code is governed by a GPL license".

Update it there as well to clear the confusion.

Alternatively:
- drop these two lines altogether, since they're not consistently found in all `.go` files
- add those two lines in `.go` files where it's missing